### PR TITLE
exporting workspace for convenience

### DIFF
--- a/run-folder-as-tests.sh
+++ b/run-folder-as-tests.sh
@@ -49,6 +49,7 @@ fi
 if [[ x${WORKSPACE} == x ]]; then
   WORKSPACE=/mnt/workspace
 fi
+export WORKSPACE
 
 # ${SCRATCH_DISK} should be set by user. If not, lets use some default.
 if [[ x${SCRATCH_DISK} == x ]]; then


### PR DESCRIPTION
workspace can be often used within the inside of a shell testscript for various purposes.. rather then defining it again, or risking that the variable would not be visible, we should export it to make sure all child processes within the same shell can reach it