### PR TITLE
jtreg-shell-xml.sh: escape special characters in skipMessage

### DIFF
--- a/jtreg-shell-xml.sh
+++ b/jtreg-shell-xml.sh
@@ -10,6 +10,14 @@
 # Why logfile and previewPathToLogfile are different? On system where the xml will be shown, the path may be compellty different
 #  then on the system where t was run, or not present at all. Thats why. logFile is not propagated, only previewPathToLogfile is.
 
+function escapeForXml {
+	# escape & " < >
+	printf '%s' "$1" | sed \
+	-e 's/\&/\&amp;/g' \
+	-e 's/"/\&quot;/g' \
+	-e 's/</\&lt;/g' \
+	-e 's/>/\&gt;/g'
+}
 
 function printXmlTest { # classname testname, time, file, jenkins view_dir
   local classname="$1"
@@ -22,8 +30,9 @@ function printXmlTest { # classname testname, time, file, jenkins view_dir
     echo "/>"
   else
     echo ">"
-    if cat $logFile | grep -q "^\!skipped!" ; then
-      local skipMessage=`cat $logFile | grep -e   "^\!skipped!" | tail -n 1`
+    if cat $logFile | grep -q '^!skipped!' ; then
+      local skipMessage=`cat $logFile | grep -e   '^!skipped!' | tail -n 1`
+      skipMessage="$(escapeForXml "${skipMessage}")"
       echo "<skipped message=\"$skipMessage - see: $viewFileStub\"/>"
     else
       echo "      <failure message=\"see: $viewFileStub\" type=\"non zero sub-shell return code\">"

--- a/jtreg-shell-xml.sh
+++ b/jtreg-shell-xml.sh
@@ -10,9 +10,9 @@
 # Why logfile and previewPathToLogfile are different? On system where the xml will be shown, the path may be compellty different
 #  then on the system where t was run, or not present at all. Thats why. logFile is not propagated, only previewPathToLogfile is.
 
+# when piped, escape & " < >
 function escapeForXml {
-	# escape & " < >
-	printf '%s' "$1" | sed \
+	sed \
 	-e 's/\&/\&amp;/g' \
 	-e 's/"/\&quot;/g' \
 	-e 's/</\&lt;/g' \
@@ -31,8 +31,7 @@ function printXmlTest { # classname testname, time, file, jenkins view_dir
   else
     echo ">"
     if cat $logFile | grep -q '^!skipped!' ; then
-      local skipMessage=`cat $logFile | grep -e   '^!skipped!' | tail -n 1`
-      skipMessage="$(escapeForXml "${skipMessage}")"
+       local skipMessage=$(cat $logFile | grep -e   '^!skipped!' | tail -n 1 | escapeForXml )
       echo "<skipped message=\"$skipMessage - see: $viewFileStub\"/>"
     else
       echo "      <failure message=\"see: $viewFileStub\" type=\"non zero sub-shell return code\">"


### PR DESCRIPTION
This escapes special characters (for xml) in skipMessage.

When doing it I also changed skipped pattern (from  `"^\!skipped!"` to `'^!skipped!'`) to fix:
```
grep: warning: stray \ before !
```

Tested function with downloaded log file, seems to work properly after the change.